### PR TITLE
add jax-triton's input_output_alias

### DIFF
--- a/liger_kernels/cross_entropy.py
+++ b/liger_kernels/cross_entropy.py
@@ -21,10 +21,11 @@ from utils import element_mul_kernel, get_stride
 
 @triton.jit
 def liger_cross_entropy_kernel(
-    X_ptr,
+    _, # alias for X_ptr
     Y_ptr,
     n_non_ignore_ptr,
     loss_ptr,
+    X_ptr,
     X_stride,
     Y_stride,
     loss_stride,

--- a/liger_kernels/utils.py
+++ b/liger_kernels/utils.py
@@ -6,8 +6,9 @@ import triton.language as tl
 
 @triton.jit
 def element_mul_kernel(
-    X_ptr,
+    _,  # alias for X_ptr
     grad_output_ptr,
+    X_ptr,
     X_stride,
     n_cols,
     BLOCK_SIZE: tl.constexpr,


### PR DESCRIPTION
`jax-triton` seems to support [`input_output_alias: dict[int, int]`](https://github.com/jax-ml/jax-triton/blob/f0ed12f9e9cea03a37001a7a708e9bb71c3ad144/jax_triton/triton_lib.py#L518) now, so we can make in-place changes and make XLA aware of the dependecy:
* in the kernel you operate on the output (which is no-copy, hopefully, prefilled, aliased to an input)
* in XLA, you capture all the modified inputs as outputs of the `jax_triton.triton_call` to add a data compute dependency

Example here: [https://github.com/jax-ml/jax-triton/blob/f0ed12f9e9cea03a37001a7a708e9bb71c3ad144/tests/triton_call_test.py#L286](https://github.com/jax-ml/jax-triton/blob/f0ed12f9e9cea03a37001a7a708e9bb71c3ad144/tests/triton_call_test.py#L286)